### PR TITLE
Patch 1

### DIFF
--- a/src/main/java/storm/trident/state/mysql/MysqlState.java
+++ b/src/main/java/storm/trident/state/mysql/MysqlState.java
@@ -40,7 +40,12 @@ public class MysqlState<T> implements IBackingMap<T> {
 		this.config = config;
 		try {
 			Class.forName("com.mysql.jdbc.Driver");
-			connection = DriverManager.getConnection(config.getUrl());
+			if(config.getUsername() == null || config.getPassword() == null){
+				connection = DriverManager.getConnection(config.getUrl());
+			}else{
+				connection = DriverManager.getConnection(config.getUrl(),config.getUsername(),config.getPassword());	
+			}
+			
 		} catch (final SQLException | ClassNotFoundException ex) {
 			logger.error("Failed to establish DB connection", ex);
 		}

--- a/src/main/java/storm/trident/state/mysql/MysqlStateConfig.java
+++ b/src/main/java/storm/trident/state/mysql/MysqlStateConfig.java
@@ -18,6 +18,26 @@ public class MysqlStateConfig implements Serializable {
 	private static final int DEFAULT_CACHE_SIZE = 5000;
 	private static final int DEFAULT_BATCH_SIZE = 5000;
 
+	private String username = null;
+	private String password = null;
+	
+	public String getUsername() {
+		return username;
+	}
+
+	public void setUsername(String username) {
+		this.username = username;
+	}
+
+	public String getPassword() {
+		return password;
+	}
+
+	public void setPassword(String password) {
+		this.password = password;
+	}
+
+
 	public String getUrl() {
 		return url;
 	}


### PR DESCRIPTION
Previous implementation forced developer to use string concatenation to get connection instance with username and password. By this way, mentioned code is abstracted and we can use just  "Connection java.sql.DriverManager.getConnection(String url, String user, String password) throws SQLException" method. I also added two properties to MysqlStateConfig class to hold username and password information.